### PR TITLE
makes download-fiind-annotations-from-brainbox compatible with python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/resources/notebooks/brainbox/download-fiind-annotations-from-brainbox.ipynb
+++ b/resources/notebooks/brainbox/download-fiind-annotations-from-brainbox.ipynb
@@ -27,14 +27,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import urllib.request as urlreq\n",
+    "from __future__ import unicode_literals\n",
+    "\n",
+    "# if necessary, install tqdm\n",
+    "#!pip install tqdm \n",
+    "\n",
+    "import requests as urlreq\n",
     "import re\n",
     "import os\n",
-    "import json\n",
     "from tqdm import tqdm"
    ]
   },
@@ -47,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -93,9 +97,8 @@
     "mri_url = \"https://brainbox.pasteur.fr/mri/json?url=\"\n",
     "\n",
     "# Download project description\n",
-    "res = urlreq.urlopen( prj_url )\n",
-    "txt = res.read()\n",
-    "prj = json.loads( txt )\n",
+    "res = urlreq.get( prj_url )\n",
+    "prj = res.json()\n",
     "\n",
     "# Get number of files\n",
     "nfiles = len( prj['files']['list'] )\n",
@@ -111,14 +114,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 28/28 [00:08<00:00,  3.38it/s]\n"
+      "100%|██████████| 28/28 [00:23<00:00,  1.21it/s]\n"
      ]
     }
    ],
@@ -128,9 +131,8 @@
     "    \n",
     "    # Download MRI description\n",
     "    brainbox_url = mri_url + prj['files']['list'][isub]\n",
-    "    res = urlreq.urlopen( brainbox_url )\n",
-    "    txt = res.read()\n",
-    "    mri = json.loads( txt )\n",
+    "    res = urlreq.get( brainbox_url )\n",
+    "    mri = res.json()\n",
     "    subID = mri['name']\n",
     "\n",
     "    # Search for the mask names atlases within the annotations\n",
@@ -162,15 +164,22 @@
     "                # Download the atlas\n",
     "                atlas_url = base + filename\n",
     "                try:\n",
-    "                    f = urlreq.urlopen( atlas_url )\n",
+    "                    f = urlreq.get( atlas_url )\n",
     "                    local_file = open( dst + \"/\" + myname, \"wb\" )\n",
-    "                    local_file.write( f.read() )\n",
+    "                    local_file.write( f.content )\n",
     "                    local_file.close()\n",
     "                except:\n",
     "                    continue\n",
     "    if index<0:\n",
     "        print(\"No atlas contained the requested masks\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -189,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
also adds .gitignore and uses requests instead of urllib for even simpler code that works in both python 2.7 and 3.
The file "download-fiind-annotations-from-brainbox.html" should be re-generated when this pull request is accepted.